### PR TITLE
Add unit tests for models directory

### DIFF
--- a/tests/unit/models/__init__.py
+++ b/tests/unit/models/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for models."""

--- a/tests/unit/models/test_bot_response.py
+++ b/tests/unit/models/test_bot_response.py
@@ -1,0 +1,329 @@
+"""Unit tests for BotResponse model."""
+
+from datetime import date, datetime, timezone
+from uuid import uuid4
+
+import pytest
+
+from src.models.bot_response import BotResponse, Citation
+
+
+class TestCitation:
+    """Test Citation model."""
+
+    def test_validate_success(self):
+        """Test successful citation validation."""
+        citation = Citation(
+            document_name="rules-1-phases.md",
+            section="Movement Phase",
+            quote="You can move up to your Movement characteristic.",
+            document_type="core-rules",
+            last_update_date=date.today(),
+        )
+        # Should not raise
+        citation.validate()
+
+    def test_citation_creation(self):
+        """Test creating a citation."""
+        citation = Citation(
+            document_name="faq.md",
+            section="Charge Phase",
+            quote="A charge requires line of sight.",
+            document_type="faq",
+            last_update_date=date(2024, 10, 1),
+        )
+
+        assert citation.document_name == "faq.md"
+        assert citation.section == "Charge Phase"
+        assert citation.document_type == "faq"
+
+
+class TestBotResponse:
+    """Test BotResponse model."""
+
+    def test_validate_success(self):
+        """Test successful bot response validation."""
+        citation = Citation(
+            document_name="rules.md",
+            section="Combat",
+            quote="Attack sequence follows these steps.",
+            document_type="core-rules",
+            last_update_date=date.today(),
+        )
+
+        response = BotResponse(
+            response_id=uuid4(),
+            query_id=uuid4(),
+            answer_text="Yes, you can overwatch.",
+            citations=[citation],
+            confidence_score=0.9,
+            rag_score=0.8,
+            validation_passed=True,
+            llm_model="gpt-4.1",
+            token_count=150,
+            latency_ms=1200,
+            timestamp=datetime.now(timezone.utc),
+        )
+        # Should not raise
+        response.validate()
+
+    def test_should_send_high_scores(self):
+        """Test should_send with high confidence and RAG scores."""
+        citation = Citation(
+            document_name="rules.md",
+            section="Combat",
+            quote="Test quote",
+            document_type="core-rules",
+            last_update_date=date.today(),
+        )
+
+        response = BotResponse(
+            response_id=uuid4(),
+            query_id=uuid4(),
+            answer_text="Answer",
+            citations=[citation],
+            confidence_score=0.9,
+            rag_score=0.8,
+            validation_passed=True,
+            llm_model="gpt-4.1",
+            token_count=100,
+            latency_ms=1000,
+            timestamp=datetime.now(timezone.utc),
+        )
+
+        assert response.should_send() is True
+
+    def test_should_send_low_confidence(self):
+        """Test should_send with low LLM confidence."""
+        citation = Citation(
+            document_name="rules.md",
+            section="Combat",
+            quote="Test quote",
+            document_type="core-rules",
+            last_update_date=date.today(),
+        )
+
+        response = BotResponse(
+            response_id=uuid4(),
+            query_id=uuid4(),
+            answer_text="Answer",
+            citations=[citation],
+            confidence_score=0.5,  # Below threshold
+            rag_score=0.8,
+            validation_passed=False,
+            llm_model="gpt-4.1",
+            token_count=100,
+            latency_ms=1000,
+            timestamp=datetime.now(timezone.utc),
+        )
+
+        assert response.should_send() is False
+
+    def test_should_send_low_rag(self):
+        """Test should_send with low RAG score."""
+        citation = Citation(
+            document_name="rules.md",
+            section="Combat",
+            quote="Test quote",
+            document_type="core-rules",
+            last_update_date=date.today(),
+        )
+
+        response = BotResponse(
+            response_id=uuid4(),
+            query_id=uuid4(),
+            answer_text="Answer",
+            citations=[citation],
+            confidence_score=0.9,
+            rag_score=0.4,  # Below threshold
+            validation_passed=False,
+            llm_model="gpt-4.1",
+            token_count=100,
+            latency_ms=1000,
+            timestamp=datetime.now(timezone.utc),
+        )
+
+        assert response.should_send() is False
+
+    def test_should_send_custom_threshold(self):
+        """Test should_send with custom confidence threshold."""
+        citation = Citation(
+            document_name="rules.md",
+            section="Combat",
+            quote="Test quote",
+            document_type="core-rules",
+            last_update_date=date.today(),
+        )
+
+        response = BotResponse(
+            response_id=uuid4(),
+            query_id=uuid4(),
+            answer_text="Answer",
+            citations=[citation],
+            confidence_score=0.75,
+            rag_score=0.8,
+            validation_passed=True,
+            llm_model="gpt-4.1",
+            token_count=100,
+            latency_ms=1000,
+            timestamp=datetime.now(timezone.utc),
+        )
+
+        assert response.should_send(confidence_threshold=0.8) is False
+        assert response.should_send(confidence_threshold=0.7) is True
+
+    def test_split_for_discord_short_message(self):
+        """Test splitting a short message that fits in one chunk."""
+        citation = Citation(
+            document_name="rules.md",
+            section="Combat",
+            quote="Test quote",
+            document_type="core-rules",
+            last_update_date=date.today(),
+        )
+
+        response = BotResponse(
+            response_id=uuid4(),
+            query_id=uuid4(),
+            answer_text="This is a short answer.",
+            citations=[citation],
+            confidence_score=0.9,
+            rag_score=0.8,
+            validation_passed=True,
+            llm_model="gpt-4.1",
+            token_count=100,
+            latency_ms=1000,
+            timestamp=datetime.now(timezone.utc),
+        )
+
+        chunks = response.split_for_discord()
+
+        assert len(chunks) == 1
+        assert chunks[0] == "This is a short answer."
+
+    def test_split_for_discord_long_message(self):
+        """Test splitting a long message into multiple chunks."""
+        # Create a long message with sentences
+        long_text = ". ".join([f"Sentence {i}" for i in range(200)])
+
+        citation = Citation(
+            document_name="rules.md",
+            section="Combat",
+            quote="Test quote",
+            document_type="core-rules",
+            last_update_date=date.today(),
+        )
+
+        response = BotResponse(
+            response_id=uuid4(),
+            query_id=uuid4(),
+            answer_text=long_text,
+            citations=[citation],
+            confidence_score=0.9,
+            rag_score=0.8,
+            validation_passed=True,
+            llm_model="gpt-4.1",
+            token_count=100,
+            latency_ms=1000,
+            timestamp=datetime.now(timezone.utc),
+        )
+
+        chunks = response.split_for_discord()
+
+        # Should be split into multiple chunks
+        assert len(chunks) > 1
+
+        # Each chunk should be under 2000 characters
+        for chunk in chunks:
+            assert len(chunk) <= 2000
+
+    def test_create(self):
+        """Test creating BotResponse with factory method."""
+        query_id = uuid4()
+        citation = Citation(
+            document_name="rules.md",
+            section="Combat",
+            quote="Test quote",
+            document_type="core-rules",
+            last_update_date=date.today(),
+        )
+
+        response = BotResponse.create(
+            query_id=query_id,
+            answer_text="Test answer",
+            citations=[citation],
+            confidence_score=0.85,
+            rag_score=0.75,
+            llm_model="claude-sonnet-4-5-20250929",
+            token_count=200,
+            latency_ms=1500,
+        )
+
+        assert response.query_id == query_id
+        assert response.answer_text == "Test answer"
+        assert len(response.citations) == 1
+        assert response.confidence_score == 0.85
+        assert response.rag_score == 0.75
+        assert response.llm_model == "claude-sonnet-4-5-20250929"
+        assert response.token_count == 200
+        assert response.latency_ms == 1500
+        assert response.validation_passed is True  # Both scores above thresholds
+        assert isinstance(response.timestamp, datetime)
+
+    def test_create_validation_failed(self):
+        """Test creating BotResponse with validation_passed=False."""
+        citation = Citation(
+            document_name="rules.md",
+            section="Combat",
+            quote="Test quote",
+            document_type="core-rules",
+            last_update_date=date.today(),
+        )
+
+        response = BotResponse.create(
+            query_id=uuid4(),
+            answer_text="Test answer",
+            citations=[citation],
+            confidence_score=0.5,  # Below threshold
+            rag_score=0.75,
+            llm_model="gpt-4.1",
+            token_count=200,
+            latency_ms=1500,
+        )
+
+        assert response.validation_passed is False
+
+    def test_create_with_structured_data(self):
+        """Test creating BotResponse with structured data."""
+        from src.models.structured_response import StructuredLLMResponse, StructuredQuote
+
+        citation = Citation(
+            document_name="rules.md",
+            section="Combat",
+            quote="Test quote",
+            document_type="core-rules",
+            last_update_date=date.today(),
+        )
+
+        structured = StructuredLLMResponse(
+            smalltalk=False,
+            short_answer="Yes.",
+            persona_short_answer="That's correct!",
+            quotes=[StructuredQuote("Core Rules", "Some text")],
+            explanation="Here's why...",
+            persona_afterword="Hope that helps!",
+        )
+
+        response = BotResponse.create(
+            query_id=uuid4(),
+            answer_text='{"smalltalk": false}',
+            citations=[citation],
+            confidence_score=0.9,
+            rag_score=0.8,
+            llm_model="gpt-4.1",
+            token_count=200,
+            latency_ms=1500,
+            structured_data=structured,
+        )
+
+        assert response.structured_data == structured

--- a/tests/unit/models/test_conversation_context.py
+++ b/tests/unit/models/test_conversation_context.py
@@ -1,0 +1,166 @@
+"""Unit tests for ConversationContext model."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.models.conversation_context import ConversationContext, Message
+
+
+class TestMessage:
+    """Test Message dataclass."""
+
+    def test_message_creation(self):
+        """Test creating a message."""
+        timestamp = datetime.now(timezone.utc)
+        message = Message(
+            role="user",
+            text="Can I overwatch during charge?",
+            timestamp=timestamp,
+        )
+
+        assert message.role == "user"
+        assert message.text == "Can I overwatch during charge?"
+        assert message.timestamp == timestamp
+
+
+class TestConversationContext:
+    """Test ConversationContext model."""
+
+    def test_create_context_key(self):
+        """Test context key creation."""
+        key = ConversationContext.create_context_key("channel123", "user456")
+        assert key == "channel123:user456"
+
+    def test_validate_success(self):
+        """Test successful validation."""
+        context = ConversationContext(
+            context_key="channel123:user456",
+            user_id="user456",
+            channel_id="channel123",
+            message_history=[],
+            ttl_seconds=1800,
+        )
+        # Should not raise
+        context.validate()
+
+    def test_add_message(self):
+        """Test adding a message to history."""
+        context = ConversationContext.create("channel123", "user456")
+
+        context.add_message("user", "What are the charge rules?")
+
+        assert len(context.message_history) == 1
+        assert context.message_history[0].role == "user"
+        assert context.message_history[0].text == "What are the charge rules?"
+
+    def test_add_message_multiple(self):
+        """Test adding multiple messages."""
+        context = ConversationContext.create("channel123", "user456")
+
+        context.add_message("user", "Question 1")
+        context.add_message("bot", "Answer 1")
+        context.add_message("user", "Question 2")
+
+        assert len(context.message_history) == 3
+        assert context.message_history[0].role == "user"
+        assert context.message_history[1].role == "bot"
+        assert context.message_history[2].role == "user"
+
+    def test_add_message_trim_to_10(self):
+        """Test message history is trimmed to 10 messages."""
+        context = ConversationContext.create("channel123", "user456")
+
+        # Add 15 messages
+        for i in range(15):
+            context.add_message("user", f"Message {i}")
+
+        # Should only keep last 10
+        assert len(context.message_history) == 10
+        assert context.message_history[0].text == "Message 5"
+        assert context.message_history[-1].text == "Message 14"
+
+    def test_is_expired_not_expired(self):
+        """Test context is not expired within TTL."""
+        context = ConversationContext.create("channel123", "user456", ttl_seconds=1800)
+        assert context.is_expired() is False
+
+    def test_is_expired_expired(self):
+        """Test context is expired after TTL."""
+        context = ConversationContext.create("channel123", "user456", ttl_seconds=1)
+
+        # Set last activity to 2 seconds ago
+        context.last_activity = datetime.now(timezone.utc) - timedelta(seconds=2)
+
+        assert context.is_expired() is True
+
+    def test_get_recent_messages(self):
+        """Test retrieving recent messages."""
+        context = ConversationContext.create("channel123", "user456")
+
+        for i in range(8):
+            context.add_message("user", f"Message {i}")
+
+        recent = context.get_recent_messages(count=3)
+
+        assert len(recent) == 3
+        assert recent[0].text == "Message 5"
+        assert recent[1].text == "Message 6"
+        assert recent[2].text == "Message 7"
+
+    def test_get_recent_messages_fewer_than_requested(self):
+        """Test retrieving recent messages when fewer exist."""
+        context = ConversationContext.create("channel123", "user456")
+
+        context.add_message("user", "Message 1")
+        context.add_message("user", "Message 2")
+
+        recent = context.get_recent_messages(count=5)
+
+        assert len(recent) == 2
+
+    def test_clear(self):
+        """Test clearing message history."""
+        context = ConversationContext.create("channel123", "user456")
+
+        context.add_message("user", "Message 1")
+        context.add_message("user", "Message 2")
+
+        context.clear()
+
+        assert len(context.message_history) == 0
+
+    def test_create(self):
+        """Test creating new conversation context."""
+        context = ConversationContext.create(
+            channel_id="channel123",
+            user_id="user456",
+            ttl_seconds=3600,
+        )
+
+        assert context.context_key == "channel123:user456"
+        assert context.user_id == "user456"
+        assert context.channel_id == "channel123"
+        assert context.message_history == []
+        assert context.ttl_seconds == 3600
+        assert isinstance(context.last_activity, datetime)
+
+    def test_create_default_ttl(self):
+        """Test creating context with default TTL."""
+        context = ConversationContext.create("channel123", "user456")
+
+        assert context.ttl_seconds == 1800  # 30 minutes default
+
+    def test_add_message_updates_last_activity(self):
+        """Test that adding a message updates last_activity."""
+        context = ConversationContext.create("channel123", "user456")
+
+        initial_activity = context.last_activity
+
+        # Wait a tiny bit to ensure time difference
+        import time
+        time.sleep(0.01)
+
+        context.add_message("user", "New message")
+
+        assert context.last_activity > initial_activity

--- a/tests/unit/models/test_ingestion_job.py
+++ b/tests/unit/models/test_ingestion_job.py
@@ -1,0 +1,235 @@
+"""Unit tests for IngestionJob model."""
+
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+import pytest
+
+from src.models.ingestion_job import IngestionJob
+
+
+class TestIngestionJob:
+    """Test IngestionJob model."""
+
+    def test_validate_success(self):
+        """Test successful validation."""
+        job = IngestionJob(
+            job_id=uuid4(),
+            update_id=uuid4(),
+            status="running",
+            started_at=datetime.now(timezone.utc),
+        )
+        # Should not raise
+        job.validate()
+
+    def test_mark_success(self):
+        """Test marking job as successful."""
+        job = IngestionJob.start(uuid4())
+
+        job.mark_success()
+
+        assert job.status == "success"
+        assert job.completed_at is not None
+        assert isinstance(job.completed_at, datetime)
+
+    def test_mark_failed(self):
+        """Test marking job as failed."""
+        job = IngestionJob.start(uuid4())
+
+        error_msg = "PDF parsing failed"
+        job.mark_failed(error_msg)
+
+        assert job.status == "failed"
+        assert job.completed_at is not None
+        assert error_msg in job.errors
+
+    def test_mark_failed_multiple_errors(self):
+        """Test marking job as failed with multiple errors."""
+        job = IngestionJob.start(uuid4())
+
+        job.mark_failed("Error 1")
+        job.mark_failed("Error 2")
+
+        assert job.status == "failed"
+        assert "Error 1" in job.errors
+        assert "Error 2" in job.errors
+
+    def test_add_processed_file(self):
+        """Test adding processed files."""
+        job = IngestionJob.start(uuid4())
+
+        job.add_processed_file("rules-1.md")
+        job.add_processed_file("rules-2.md")
+
+        assert len(job.processed_files) == 2
+        assert "rules-1.md" in job.processed_files
+        assert "rules-2.md" in job.processed_files
+
+    def test_add_processed_file_no_duplicates(self):
+        """Test that duplicate files are not added."""
+        job = IngestionJob.start(uuid4())
+
+        job.add_processed_file("rules-1.md")
+        job.add_processed_file("rules-1.md")
+
+        assert len(job.processed_files) == 1
+
+    def test_add_warning(self):
+        """Test adding warnings."""
+        job = IngestionJob.start(uuid4())
+
+        job.add_warning("Minor formatting issue")
+        job.add_warning("Missing metadata")
+
+        assert len(job.warnings) == 2
+        assert "Minor formatting issue" in job.warnings
+
+    def test_add_warning_no_duplicates(self):
+        """Test that duplicate warnings are not added."""
+        job = IngestionJob.start(uuid4())
+
+        job.add_warning("Warning 1")
+        job.add_warning("Warning 1")
+
+        assert len(job.warnings) == 1
+
+    def test_add_error(self):
+        """Test adding errors."""
+        job = IngestionJob.start(uuid4())
+
+        job.add_error("Parse error")
+        job.add_error("Network error")
+
+        assert len(job.errors) == 2
+        assert "Parse error" in job.errors
+
+    def test_add_error_no_duplicates(self):
+        """Test that duplicate errors are not added."""
+        job = IngestionJob.start(uuid4())
+
+        job.add_error("Error 1")
+        job.add_error("Error 1")
+
+        assert len(job.errors) == 1
+
+    def test_increment_created(self):
+        """Test incrementing documents_created counter."""
+        job = IngestionJob.start(uuid4())
+
+        assert job.documents_created == 0
+
+        job.increment_created()
+        job.increment_created()
+
+        assert job.documents_created == 2
+
+    def test_increment_updated(self):
+        """Test incrementing documents_updated counter."""
+        job = IngestionJob.start(uuid4())
+
+        assert job.documents_updated == 0
+
+        job.increment_updated()
+        job.increment_updated()
+        job.increment_updated()
+
+        assert job.documents_updated == 3
+
+    def test_set_extraction_metrics(self):
+        """Test setting extraction metrics."""
+        job = IngestionJob.start(uuid4())
+
+        job.set_extraction_metrics(
+            token_count=1500,
+            cost_usd=0.05,
+            latency_ms=3000,
+        )
+
+        assert job.extraction_token_count == 1500
+        assert job.extraction_cost_usd == 0.05
+        assert job.extraction_latency_ms == 3000
+
+    def test_get_duration_seconds_not_completed(self):
+        """Test getting duration when job not completed."""
+        job = IngestionJob.start(uuid4())
+
+        duration = job.get_duration_seconds()
+
+        assert duration is None
+
+    def test_get_duration_seconds_completed(self):
+        """Test getting duration when job completed."""
+        job = IngestionJob.start(uuid4())
+
+        # Set completion time 5 seconds after start
+        job.completed_at = job.started_at + timedelta(seconds=5)
+
+        duration = job.get_duration_seconds()
+
+        assert duration == 5.0
+
+    def test_start(self):
+        """Test starting a new ingestion job."""
+        update_id = uuid4()
+
+        job = IngestionJob.start(update_id)
+
+        assert job.update_id == update_id
+        assert job.status == "running"
+        assert isinstance(job.started_at, datetime)
+        assert job.completed_at is None
+        assert job.processed_files == []
+        assert job.errors == []
+        assert job.warnings == []
+        assert job.documents_created == 0
+        assert job.documents_updated == 0
+        assert job.reingestion_triggered is False
+        assert job.extraction_token_count == 0
+
+    def test_complete_workflow(self):
+        """Test a complete ingestion workflow."""
+        job = IngestionJob.start(uuid4())
+
+        # Add some files
+        job.add_processed_file("rules-1.md")
+        job.add_processed_file("rules-2.md")
+
+        # Add some warnings
+        job.add_warning("Minor issue")
+
+        # Update counters
+        job.increment_created()
+        job.increment_created()
+
+        # Set metrics
+        job.set_extraction_metrics(1000, 0.03, 2000)
+
+        # Mark as successful
+        job.mark_success()
+
+        # Verify final state
+        assert job.status == "success"
+        assert len(job.processed_files) == 2
+        assert len(job.warnings) == 1
+        assert job.documents_created == 2
+        assert job.extraction_token_count == 1000
+        assert job.completed_at is not None
+
+    def test_failed_workflow(self):
+        """Test a failed ingestion workflow."""
+        job = IngestionJob.start(uuid4())
+
+        # Add some processing before failure
+        job.add_processed_file("rules-1.md")
+        job.increment_created()
+
+        # Add error
+        job.add_error("Critical error occurred")
+
+        # Mark as failed
+        job.mark_failed("Job failed due to critical error")
+
+        # Verify final state
+        assert job.status == "failed"
+        assert len(job.errors) == 2
+        assert job.completed_at is not None

--- a/tests/unit/models/test_pdf_update.py
+++ b/tests/unit/models/test_pdf_update.py
@@ -1,0 +1,134 @@
+"""Unit tests for PDFUpdate model."""
+
+import hashlib
+from datetime import date, datetime, timezone
+from uuid import UUID, uuid4
+
+import pytest
+
+from src.models.pdf_update import PDFUpdate
+
+
+class TestPDFUpdate:
+    """Test PDFUpdate model."""
+
+    def test_compute_file_hash(self):
+        """Test SHA-256 hash computation."""
+        content = b"test content"
+        expected = hashlib.sha256(content).hexdigest()
+        assert PDFUpdate.compute_file_hash(content) == expected
+
+    def test_compute_file_hash_empty(self):
+        """Test hash of empty content."""
+        content = b""
+        expected = hashlib.sha256(content).hexdigest()
+        assert PDFUpdate.compute_file_hash(content) == expected
+
+    def test_validate_url_https(self):
+        """Test HTTPS URL validation."""
+        assert PDFUpdate.validate_url("https://example.com/file.pdf") is True
+
+    def test_validate_url_http(self):
+        """Test HTTP URL is invalid."""
+        assert PDFUpdate.validate_url("http://example.com/file.pdf") is False
+
+    def test_validate_url_invalid(self):
+        """Test invalid URL format."""
+        assert PDFUpdate.validate_url("not-a-url") is False
+
+    def test_validate_version_semver(self):
+        """Test semver version validation."""
+        assert PDFUpdate.validate_version("1.0") is True
+        assert PDFUpdate.validate_version("3.1") is True
+        assert PDFUpdate.validate_version("10.25") is True
+
+    def test_validate_version_date_based(self):
+        """Test date-based version validation."""
+        assert PDFUpdate.validate_version("FAQ-2024-10") is True
+        assert PDFUpdate.validate_version("v2024-09") is True
+
+    def test_validate_version_invalid(self):
+        """Test invalid version formats."""
+        assert PDFUpdate.validate_version("1") is False
+        assert PDFUpdate.validate_version("1.0.0") is False
+        assert PDFUpdate.validate_version("invalid") is False
+
+    def test_validate_success(self):
+        """Test successful validation."""
+        pdf_update = PDFUpdate(
+            update_id=uuid4(),
+            pdf_filename="rules.pdf",
+            pdf_url="https://example.com/rules.pdf",
+            download_date=datetime.now(timezone.utc),
+            last_update_date=date.today(),
+            version="3.1",
+            file_size_bytes=1024,
+            file_hash="abc123",
+            extraction_status="pending",
+        )
+        # Should not raise
+        pdf_update.validate()
+
+    def test_mark_success(self):
+        """Test marking extraction as successful."""
+        pdf_update = PDFUpdate(
+            update_id=uuid4(),
+            pdf_filename="rules.pdf",
+            pdf_url="https://example.com/rules.pdf",
+            download_date=datetime.now(timezone.utc),
+            last_update_date=date.today(),
+            version="3.1",
+            file_size_bytes=1024,
+            file_hash="abc123",
+            extraction_status="pending",
+            error_message="previous error",
+        )
+
+        pdf_update.mark_success()
+
+        assert pdf_update.extraction_status == "success"
+        assert pdf_update.error_message is None
+
+    def test_mark_failed(self):
+        """Test marking extraction as failed."""
+        pdf_update = PDFUpdate(
+            update_id=uuid4(),
+            pdf_filename="rules.pdf",
+            pdf_url="https://example.com/rules.pdf",
+            download_date=datetime.now(timezone.utc),
+            last_update_date=date.today(),
+            version="3.1",
+            file_size_bytes=1024,
+            file_hash="abc123",
+            extraction_status="pending",
+        )
+
+        error_msg = "Extraction failed due to timeout"
+        pdf_update.mark_failed(error_msg)
+
+        assert pdf_update.extraction_status == "failed"
+        assert pdf_update.error_message == error_msg
+
+    def test_from_download(self):
+        """Test creating PDFUpdate from download."""
+        file_content = b"PDF content here"
+        last_update = date(2024, 10, 1)
+
+        pdf_update = PDFUpdate.from_download(
+            pdf_filename="rules.pdf",
+            pdf_url="https://example.com/rules.pdf",
+            file_content=file_content,
+            last_update_date=last_update,
+            version="3.1",
+        )
+
+        assert isinstance(pdf_update.update_id, UUID)
+        assert pdf_update.pdf_filename == "rules.pdf"
+        assert pdf_update.pdf_url == "https://example.com/rules.pdf"
+        assert pdf_update.last_update_date == last_update
+        assert pdf_update.version == "3.1"
+        assert pdf_update.file_size_bytes == len(file_content)
+        assert pdf_update.file_hash == PDFUpdate.compute_file_hash(file_content)
+        assert pdf_update.extraction_status == "pending"
+        assert pdf_update.error_message is None
+        assert isinstance(pdf_update.download_date, datetime)

--- a/tests/unit/models/test_rag_context.py
+++ b/tests/unit/models/test_rag_context.py
@@ -1,0 +1,257 @@
+"""Unit tests for RAGContext model."""
+
+from datetime import date
+from uuid import uuid4
+
+import pytest
+
+from src.models.rag_context import DocumentChunk, RAGContext
+
+
+class TestDocumentChunk:
+    """Test DocumentChunk model."""
+
+    def test_validate_success(self):
+        """Test successful chunk validation."""
+        chunk = DocumentChunk(
+            chunk_id=uuid4(),
+            document_id=uuid4(),
+            text="You can move up to your Movement characteristic.",
+            header="Movement Phase",
+            header_level=2,
+            metadata={
+                "source": "Core Rules v3.1",
+                "doc_type": "core-rules",
+                "publication_date": "2024-10-01",
+            },
+            relevance_score=0.85,
+            position_in_doc=1,
+        )
+        # Should not raise
+        chunk.validate()
+
+    def test_chunk_creation(self):
+        """Test creating a document chunk."""
+        chunk_id = uuid4()
+        doc_id = uuid4()
+
+        chunk = DocumentChunk(
+            chunk_id=chunk_id,
+            document_id=doc_id,
+            text="Charge rules text",
+            header="Charge Phase",
+            header_level=3,
+            metadata={
+                "source": "FAQ",
+                "doc_type": "faq",
+                "publication_date": "2024-09-15",
+            },
+            relevance_score=0.92,
+            position_in_doc=5,
+        )
+
+        assert chunk.chunk_id == chunk_id
+        assert chunk.document_id == doc_id
+        assert chunk.text == "Charge rules text"
+        assert chunk.header == "Charge Phase"
+        assert chunk.header_level == 3
+        assert chunk.relevance_score == 0.92
+        assert chunk.position_in_doc == 5
+
+
+class TestRAGContext:
+    """Test RAGContext model."""
+
+    def _create_test_chunk(self, relevance_score: float) -> DocumentChunk:
+        """Helper to create a test chunk with given relevance."""
+        return DocumentChunk(
+            chunk_id=uuid4(),
+            document_id=uuid4(),
+            text=f"Test content with relevance {relevance_score}",
+            header="Test Header",
+            header_level=2,
+            metadata={
+                "source": "Test",
+                "doc_type": "core-rules",
+                "publication_date": "2024-10-01",
+            },
+            relevance_score=relevance_score,
+            position_in_doc=1,
+        )
+
+    def test_validate_success(self):
+        """Test successful RAGContext validation."""
+        chunks = [
+            self._create_test_chunk(0.9),
+            self._create_test_chunk(0.8),
+            self._create_test_chunk(0.7),
+        ]
+
+        context = RAGContext(
+            context_id=uuid4(),
+            query_id=uuid4(),
+            document_chunks=chunks,
+            relevance_scores=[0.9, 0.8, 0.7],
+            total_chunks=3,
+            avg_relevance=0.8,
+            meets_threshold=True,
+        )
+        # Should not raise
+        context.validate()
+
+    def test_from_retrieval(self):
+        """Test creating RAGContext from retrieval results."""
+        query_id = uuid4()
+        chunks = [
+            self._create_test_chunk(0.9),
+            self._create_test_chunk(0.8),
+            self._create_test_chunk(0.7),
+        ]
+
+        context = RAGContext.from_retrieval(query_id, chunks)
+
+        assert context.query_id == query_id
+        assert context.document_chunks == chunks
+        assert context.relevance_scores == [0.9, 0.8, 0.7]
+        assert context.total_chunks == 3
+        assert context.avg_relevance == pytest.approx((0.9 + 0.8 + 0.7) / 3)
+        assert context.meets_threshold is True  # Above 0.45 threshold
+
+    def test_from_retrieval_below_threshold(self):
+        """Test creating RAGContext with low relevance scores."""
+        query_id = uuid4()
+        chunks = [
+            self._create_test_chunk(0.3),
+            self._create_test_chunk(0.2),
+            self._create_test_chunk(0.1),
+        ]
+
+        context = RAGContext.from_retrieval(query_id, chunks)
+
+        assert context.avg_relevance == pytest.approx((0.3 + 0.2 + 0.1) / 3)
+        assert context.meets_threshold is False  # Below 0.45 threshold
+
+    def test_from_retrieval_custom_threshold(self):
+        """Test creating RAGContext with custom threshold."""
+        query_id = uuid4()
+        chunks = [
+            self._create_test_chunk(0.5),
+            self._create_test_chunk(0.4),
+        ]
+
+        # With default threshold (0.45), avg is 0.45, should meet threshold
+        context = RAGContext.from_retrieval(query_id, chunks, min_relevance=0.45)
+        assert context.meets_threshold is True
+
+        # With higher threshold (0.6), should not meet
+        context = RAGContext.from_retrieval(query_id, chunks, min_relevance=0.6)
+        assert context.meets_threshold is False
+
+    def test_empty(self):
+        """Test creating empty RAGContext."""
+        query_id = uuid4()
+
+        context = RAGContext.empty(query_id)
+
+        assert context.query_id == query_id
+        assert context.document_chunks == []
+        assert context.relevance_scores == []
+        assert context.total_chunks == 0
+        assert context.avg_relevance == 0.0
+        assert context.meets_threshold is False
+
+    def test_from_retrieval_single_chunk(self):
+        """Test creating RAGContext with single chunk."""
+        query_id = uuid4()
+        chunks = [self._create_test_chunk(0.95)]
+
+        context = RAGContext.from_retrieval(query_id, chunks)
+
+        assert context.total_chunks == 1
+        assert context.avg_relevance == 0.95
+        assert context.meets_threshold is True
+
+    def test_from_retrieval_many_chunks(self):
+        """Test creating RAGContext with many chunks."""
+        query_id = uuid4()
+        chunks = [self._create_test_chunk(0.9 - i * 0.05) for i in range(10)]
+
+        context = RAGContext.from_retrieval(query_id, chunks)
+
+        assert context.total_chunks == 10
+        assert len(context.document_chunks) == 10
+        assert len(context.relevance_scores) == 10
+
+    def test_avg_relevance_calculation(self):
+        """Test that average relevance is calculated correctly."""
+        query_id = uuid4()
+        chunks = [
+            self._create_test_chunk(1.0),
+            self._create_test_chunk(0.8),
+            self._create_test_chunk(0.6),
+            self._create_test_chunk(0.4),
+        ]
+
+        context = RAGContext.from_retrieval(query_id, chunks)
+
+        expected_avg = (1.0 + 0.8 + 0.6 + 0.4) / 4
+        assert context.avg_relevance == pytest.approx(expected_avg)
+
+    def test_threshold_boundary_conditions(self):
+        """Test threshold at boundary conditions."""
+        query_id = uuid4()
+
+        # Exactly at threshold
+        chunks = [self._create_test_chunk(0.45)]
+        context = RAGContext.from_retrieval(query_id, chunks, min_relevance=0.45)
+        assert context.meets_threshold is True
+
+        # Just below threshold
+        chunks = [self._create_test_chunk(0.44)]
+        context = RAGContext.from_retrieval(query_id, chunks, min_relevance=0.45)
+        assert context.meets_threshold is False
+
+        # Just above threshold
+        chunks = [self._create_test_chunk(0.46)]
+        context = RAGContext.from_retrieval(query_id, chunks, min_relevance=0.45)
+        assert context.meets_threshold is True
+
+    def test_relevance_scores_match_chunks(self):
+        """Test that relevance_scores list matches chunk scores."""
+        query_id = uuid4()
+        scores = [0.95, 0.85, 0.75, 0.65]
+        chunks = [self._create_test_chunk(score) for score in scores]
+
+        context = RAGContext.from_retrieval(query_id, chunks)
+
+        assert context.relevance_scores == scores
+        for i, chunk in enumerate(context.document_chunks):
+            assert chunk.relevance_score == context.relevance_scores[i]
+
+    def test_chunks_preserve_order(self):
+        """Test that chunk order is preserved from retrieval."""
+        query_id = uuid4()
+        chunks = [
+            self._create_test_chunk(0.9),
+            self._create_test_chunk(0.8),
+            self._create_test_chunk(0.7),
+        ]
+
+        context = RAGContext.from_retrieval(query_id, chunks)
+
+        # Order should be preserved
+        assert context.document_chunks[0].relevance_score == 0.9
+        assert context.document_chunks[1].relevance_score == 0.8
+        assert context.document_chunks[2].relevance_score == 0.7
+
+    def test_empty_context_properties(self):
+        """Test properties of empty context."""
+        query_id = uuid4()
+        context = RAGContext.empty(query_id)
+
+        assert len(context.document_chunks) == 0
+        assert len(context.relevance_scores) == 0
+        assert context.total_chunks == 0
+        assert context.avg_relevance == 0.0
+        assert context.meets_threshold is False
+        assert isinstance(context.context_id, type(uuid4()))

--- a/tests/unit/models/test_rule_document.py
+++ b/tests/unit/models/test_rule_document.py
@@ -1,0 +1,228 @@
+"""Unit tests for RuleDocument model."""
+
+import hashlib
+from datetime import date, datetime, timezone
+from uuid import UUID
+
+import pytest
+
+from src.models.rule_document import RuleDocument
+
+
+class TestRuleDocument:
+    """Test RuleDocument model."""
+
+    def test_compute_hash(self):
+        """Test computing SHA-256 hash of content."""
+        content = "# Rules\n\nSome rule content here."
+        expected = hashlib.sha256(content.encode()).hexdigest()
+
+        result = RuleDocument.compute_hash(content)
+
+        assert result == expected
+        assert len(result) == 64  # SHA-256 hex length
+
+    def test_compute_hash_consistent(self):
+        """Test that hash computation is consistent."""
+        content = "Test content"
+
+        hash1 = RuleDocument.compute_hash(content)
+        hash2 = RuleDocument.compute_hash(content)
+
+        assert hash1 == hash2
+
+    def test_compute_hash_different_content(self):
+        """Test that different content produces different hashes."""
+        hash1 = RuleDocument.compute_hash("Content 1")
+        hash2 = RuleDocument.compute_hash("Content 2")
+
+        assert hash1 != hash2
+
+    def test_validate_filename_valid(self):
+        """Test validating valid filenames."""
+        assert RuleDocument.validate_filename("rules-1-phases.md") is True
+        assert RuleDocument.validate_filename("faq.md") is True
+        assert RuleDocument.validate_filename("team-greenskins.md") is True
+
+    def test_validate_filename_invalid(self):
+        """Test validating invalid filenames."""
+        assert RuleDocument.validate_filename("Rules.md") is False  # Capital letter
+        assert RuleDocument.validate_filename("rules_1.md") is False  # Underscore
+        assert RuleDocument.validate_filename("rules.txt") is False  # Wrong extension
+        assert RuleDocument.validate_filename("rules") is False  # No extension
+
+    def test_validate_document_type_valid(self):
+        """Test validating valid document types."""
+        assert RuleDocument.validate_document_type("core-rules") is True
+        assert RuleDocument.validate_document_type("faq") is True
+        assert RuleDocument.validate_document_type("team-rules") is True
+        assert RuleDocument.validate_document_type("ops") is True
+        assert RuleDocument.validate_document_type("killzone") is True
+
+    def test_validate_document_type_invalid(self):
+        """Test validating invalid document types."""
+        assert RuleDocument.validate_document_type("invalid") is False
+        assert RuleDocument.validate_document_type("Core-Rules") is False
+        assert RuleDocument.validate_document_type("") is False
+
+    def test_validate_success(self):
+        """Test successful document validation."""
+        doc = RuleDocument(
+            document_id=UUID("12345678-1234-5678-1234-567812345678"),
+            filename="rules-1-phases.md",
+            content="# Rules\n\nContent here.",
+            metadata={
+                "source": "Core Rules v3.1",
+                "last_update_date": "2024-10-01",
+                "document_type": "core-rules",
+            },
+            version="3.1",
+            last_update_date=date(2024, 10, 1),
+            document_type="core-rules",
+            last_updated=datetime.now(timezone.utc),
+            hash="abc123",
+        )
+        # Should not raise
+        doc.validate()
+
+    def test_has_changed_no_change(self):
+        """Test detecting no change in content."""
+        content = "# Original content"
+        doc = RuleDocument(
+            document_id=UUID("12345678-1234-5678-1234-567812345678"),
+            filename="rules.md",
+            content=content,
+            metadata={
+                "source": "Core Rules",
+                "last_update_date": "2024-10-01",
+                "document_type": "core-rules",
+            },
+            version="3.1",
+            last_update_date=date(2024, 10, 1),
+            document_type="core-rules",
+            last_updated=datetime.now(timezone.utc),
+            hash=RuleDocument.compute_hash(content),
+        )
+
+        # Same content should return False
+        assert doc.has_changed(content) is False
+
+    def test_has_changed_content_changed(self):
+        """Test detecting changed content."""
+        original_content = "# Original content"
+        doc = RuleDocument(
+            document_id=UUID("12345678-1234-5678-1234-567812345678"),
+            filename="rules.md",
+            content=original_content,
+            metadata={
+                "source": "Core Rules",
+                "last_update_date": "2024-10-01",
+                "document_type": "core-rules",
+            },
+            version="3.1",
+            last_update_date=date(2024, 10, 1),
+            document_type="core-rules",
+            last_updated=datetime.now(timezone.utc),
+            hash=RuleDocument.compute_hash(original_content),
+        )
+
+        new_content = "# Updated content"
+
+        # Different content should return True
+        assert doc.has_changed(new_content) is True
+
+    def test_from_markdown_file(self):
+        """Test creating RuleDocument from markdown file."""
+        filename = "rules-1-phases.md"
+        content = "# Movement Phase\n\nYou can move up to your Movement characteristic."
+        metadata = {
+            "source": "Core Rules v3.1",
+            "last_update_date": "2024-10-01",
+            "document_type": "core-rules",
+        }
+
+        doc = RuleDocument.from_markdown_file(
+            filename=filename,
+            content=content,
+            metadata=metadata,
+        )
+
+        assert isinstance(doc.document_id, UUID)
+        assert doc.filename == filename
+        assert doc.content == content
+        assert doc.metadata == metadata
+        assert doc.version == "Core Rules v3.1"
+        assert doc.last_update_date == date(2024, 10, 1)
+        assert doc.document_type == "core-rules"
+        assert isinstance(doc.last_updated, datetime)
+        assert doc.hash == RuleDocument.compute_hash(content)
+
+    def test_from_markdown_file_with_date_object(self):
+        """Test creating RuleDocument when metadata has date object."""
+        metadata = {
+            "source": "FAQ v2024-10",
+            "last_update_date": date(2024, 10, 15),  # Already a date object
+            "document_type": "faq",
+        }
+
+        doc = RuleDocument.from_markdown_file(
+            filename="faq.md",
+            content="# FAQ",
+            metadata=metadata,
+        )
+
+        assert doc.last_update_date == date(2024, 10, 15)
+        assert doc.document_type == "faq"
+
+    def test_from_markdown_file_all_document_types(self):
+        """Test creating documents with all valid document types."""
+        doc_types = ["core-rules", "faq", "team-rules", "ops", "killzone"]
+
+        for doc_type in doc_types:
+            metadata = {
+                "source": "Test",
+                "last_update_date": "2024-10-01",
+                "document_type": doc_type,
+            }
+
+            doc = RuleDocument.from_markdown_file(
+                filename="test.md",
+                content="Content",
+                metadata=metadata,
+            )
+
+            assert doc.document_type == doc_type
+
+    def test_version_from_metadata_source(self):
+        """Test that version is extracted from metadata source."""
+        metadata = {
+            "source": "Team Rules: Greenskins v1.5",
+            "last_update_date": "2024-10-01",
+            "document_type": "team-rules",
+        }
+
+        doc = RuleDocument.from_markdown_file(
+            filename="team-greenskins.md",
+            content="# Greenskins",
+            metadata=metadata,
+        )
+
+        assert doc.version == "Team Rules: Greenskins v1.5"
+
+    def test_hash_matches_content(self):
+        """Test that document hash matches the content."""
+        content = "# Test Content\n\nSome rules here."
+        metadata = {
+            "source": "Test",
+            "last_update_date": "2024-10-01",
+            "document_type": "core-rules",
+        }
+
+        doc = RuleDocument.from_markdown_file(
+            filename="test.md",
+            content=content,
+            metadata=metadata,
+        )
+
+        expected_hash = RuleDocument.compute_hash(content)
+        assert doc.hash == expected_hash

--- a/tests/unit/models/test_structured_response.py
+++ b/tests/unit/models/test_structured_response.py
@@ -1,0 +1,259 @@
+"""Unit tests for StructuredLLMResponse model."""
+
+import json
+
+import pytest
+
+from src.models.structured_response import StructuredLLMResponse, StructuredQuote
+
+
+class TestStructuredQuote:
+    """Test StructuredQuote model."""
+
+    def test_to_markdown(self):
+        """Test converting quote to markdown format."""
+        quote = StructuredQuote(
+            quote_title="Core Rules: Movement",
+            quote_text="You can move up to your Movement characteristic.",
+        )
+
+        markdown = quote.to_markdown()
+
+        assert markdown == "> **Core Rules: Movement**\n> You can move up to your Movement characteristic."
+
+    def test_to_markdown_with_special_characters(self):
+        """Test converting quote with special characters."""
+        quote = StructuredQuote(
+            quote_title="FAQ: Charge & Combat",
+            quote_text="You must declare charge targets before rolling.",
+        )
+
+        markdown = quote.to_markdown()
+
+        assert "**FAQ: Charge & Combat**" in markdown
+        assert "You must declare charge targets before rolling." in markdown
+
+
+class TestStructuredLLMResponse:
+    """Test StructuredLLMResponse model."""
+
+    def test_to_markdown(self):
+        """Test converting structured response to markdown."""
+        response = StructuredLLMResponse(
+            smalltalk=False,
+            short_answer="Yes.",
+            persona_short_answer="That's correct!",
+            quotes=[
+                StructuredQuote(
+                    quote_title="Core Rules: Overwatch",
+                    quote_text="You can overwatch in the shooting phase.",
+                )
+            ],
+            explanation="Overwatch is a special action that allows you to shoot during the opponent's charge phase.",
+            persona_afterword="Hope that helps clarify the rules!",
+        )
+
+        markdown = response.to_markdown()
+
+        assert "**Yes.** That's correct!" in markdown
+        assert "> **Core Rules: Overwatch**" in markdown
+        assert "> You can overwatch in the shooting phase." in markdown
+        assert "## Explanation" in markdown
+        assert "Overwatch is a special action" in markdown
+        assert "Hope that helps clarify the rules!" in markdown
+
+    def test_to_markdown_multiple_quotes(self):
+        """Test converting response with multiple quotes."""
+        response = StructuredLLMResponse(
+            smalltalk=False,
+            short_answer="No.",
+            persona_short_answer="Unfortunately not.",
+            quotes=[
+                StructuredQuote(
+                    quote_title="Core Rules: Movement",
+                    quote_text="Movement rules here.",
+                ),
+                StructuredQuote(
+                    quote_title="Core Rules: Charge",
+                    quote_text="Charge rules here.",
+                ),
+            ],
+            explanation="Detailed explanation.",
+            persona_afterword="Let me know if you need more info!",
+        )
+
+        markdown = response.to_markdown()
+
+        # Both quotes should be present
+        assert "> **Core Rules: Movement**" in markdown
+        assert "> **Core Rules: Charge**" in markdown
+
+    def test_from_json_valid(self):
+        """Test parsing valid JSON into structured response."""
+        json_str = json.dumps({
+            "smalltalk": False,
+            "short_answer": "Yes.",
+            "persona_short_answer": "Absolutely!",
+            "quotes": [
+                {
+                    "quote_title": "Core Rules",
+                    "quote_text": "Some rule text.",
+                }
+            ],
+            "explanation": "This is because...",
+            "persona_afterword": "Happy gaming!",
+        })
+
+        response = StructuredLLMResponse.from_json(json_str)
+
+        assert response.smalltalk is False
+        assert response.short_answer == "Yes."
+        assert response.persona_short_answer == "Absolutely!"
+        assert len(response.quotes) == 1
+        assert response.quotes[0].quote_title == "Core Rules"
+        assert response.quotes[0].quote_text == "Some rule text."
+        assert response.explanation == "This is because..."
+        assert response.persona_afterword == "Happy gaming!"
+
+    def test_from_json_multiple_quotes(self):
+        """Test parsing JSON with multiple quotes."""
+        json_str = json.dumps({
+            "smalltalk": False,
+            "short_answer": "No.",
+            "persona_short_answer": "Not quite.",
+            "quotes": [
+                {"quote_title": "Rule 1", "quote_text": "Text 1"},
+                {"quote_title": "Rule 2", "quote_text": "Text 2"},
+                {"quote_title": "Rule 3", "quote_text": "Text 3"},
+            ],
+            "explanation": "Explanation",
+            "persona_afterword": "Afterword",
+        })
+
+        response = StructuredLLMResponse.from_json(json_str)
+
+        assert len(response.quotes) == 3
+        assert response.quotes[0].quote_title == "Rule 1"
+        assert response.quotes[1].quote_title == "Rule 2"
+        assert response.quotes[2].quote_title == "Rule 3"
+
+    def test_from_json_smalltalk_true(self):
+        """Test parsing JSON with smalltalk=true."""
+        json_str = json.dumps({
+            "smalltalk": True,
+            "short_answer": "Hello!",
+            "persona_short_answer": "How can I help?",
+            "quotes": [],
+            "explanation": "I'm here to answer your Kill Team questions.",
+            "persona_afterword": "What would you like to know?",
+        })
+
+        response = StructuredLLMResponse.from_json(json_str)
+
+        assert response.smalltalk is True
+        assert response.quotes == []
+
+    def test_validate_success(self):
+        """Test successful validation."""
+        response = StructuredLLMResponse(
+            smalltalk=False,
+            short_answer="Yes.",
+            persona_short_answer="Correct!",
+            quotes=[
+                StructuredQuote("Core Rules", "Text here")
+            ],
+            explanation="Because of the rules...",
+            persona_afterword="Hope that helps!",
+        )
+        # Should not raise
+        response.validate()
+
+    def test_validate_smalltalk_no_quotes_required(self):
+        """Test validation allows empty quotes for smalltalk."""
+        response = StructuredLLMResponse(
+            smalltalk=True,
+            short_answer="Hi!",
+            persona_short_answer="Hello there!",
+            quotes=[],  # Empty quotes OK for smalltalk
+            explanation="I'm a bot.",
+            persona_afterword="Ask me anything!",
+        )
+        # Should not raise
+        response.validate()
+
+    def test_markdown_format_structure(self):
+        """Test that markdown format has correct structure."""
+        response = StructuredLLMResponse(
+            smalltalk=False,
+            short_answer="Yes.",
+            persona_short_answer="That's right!",
+            quotes=[
+                StructuredQuote("Rule 1", "Quote 1"),
+                StructuredQuote("Rule 2", "Quote 2"),
+            ],
+            explanation="Explanation text here.",
+            persona_afterword="Good luck!",
+        )
+
+        markdown = response.to_markdown()
+
+        # Check structure order
+        lines = markdown.split("\n")
+
+        # First line should have short answer
+        assert "**Yes.**" in lines[0]
+
+        # Should have blank lines between sections
+        assert "" in lines
+
+        # Should have explanation header
+        assert "## Explanation" in markdown
+
+    def test_to_markdown_preserves_formatting(self):
+        """Test that to_markdown preserves text formatting."""
+        response = StructuredLLMResponse(
+            smalltalk=False,
+            short_answer="Yes.",
+            persona_short_answer="Exactly!",
+            quotes=[
+                StructuredQuote(
+                    "Core Rules",
+                    "Line 1\nLine 2\nLine 3"
+                )
+            ],
+            explanation="Multi-line\nexplanation\nhere.",
+            persona_afterword="Enjoy!",
+        )
+
+        markdown = response.to_markdown()
+
+        # Multiline text should be preserved
+        assert "Line 1\nLine 2\nLine 3" in markdown
+        assert "Multi-line\nexplanation\nhere." in markdown
+
+    def test_from_json_to_markdown_roundtrip(self):
+        """Test that from_json -> to_markdown produces expected output."""
+        json_str = json.dumps({
+            "smalltalk": False,
+            "short_answer": "No.",
+            "persona_short_answer": "Not allowed.",
+            "quotes": [
+                {
+                    "quote_title": "Core Rules: Movement",
+                    "quote_text": "Cannot move after shooting.",
+                }
+            ],
+            "explanation": "The rules state you must complete movement before shooting.",
+            "persona_afterword": "Let me know if you have more questions!",
+        })
+
+        response = StructuredLLMResponse.from_json(json_str)
+        markdown = response.to_markdown()
+
+        # Verify key elements are in markdown
+        assert "**No.** Not allowed." in markdown
+        assert "> **Core Rules: Movement**" in markdown
+        assert "> Cannot move after shooting." in markdown
+        assert "## Explanation" in markdown
+        assert "The rules state you must complete movement before shooting." in markdown
+        assert "Let me know if you have more questions!" in markdown

--- a/tests/unit/models/test_user_query.py
+++ b/tests/unit/models/test_user_query.py
@@ -1,0 +1,188 @@
+"""Unit tests for UserQuery model."""
+
+import hashlib
+from datetime import datetime, timedelta, timezone
+from uuid import UUID
+
+import pytest
+
+from src.models.user_query import UserQuery
+
+
+class TestUserQuery:
+    """Test UserQuery model."""
+
+    def test_hash_user_id(self):
+        """Test hashing Discord user ID."""
+        user_id = "123456789"
+        expected = hashlib.sha256(user_id.encode()).hexdigest()
+
+        result = UserQuery.hash_user_id(user_id)
+
+        assert result == expected
+        assert len(result) == 64  # SHA-256 hex length
+
+    def test_hash_user_id_consistent(self):
+        """Test that hashing is consistent."""
+        user_id = "987654321"
+
+        result1 = UserQuery.hash_user_id(user_id)
+        result2 = UserQuery.hash_user_id(user_id)
+
+        assert result1 == result2
+
+    def test_hash_user_id_unique(self):
+        """Test that different IDs produce different hashes."""
+        hash1 = UserQuery.hash_user_id("user123")
+        hash2 = UserQuery.hash_user_id("user456")
+
+        assert hash1 != hash2
+
+    def test_create_context_id(self):
+        """Test creating composite context ID."""
+        context_id = UserQuery.create_context_id("channel123", "user456")
+
+        assert context_id == "channel123:user456"
+
+    def test_validate_success(self):
+        """Test successful validation."""
+        query = UserQuery(
+            query_id=UUID("12345678-1234-5678-1234-567812345678"),
+            user_id="hashed_user_id",
+            channel_id="channel123",
+            message_text="Can I overwatch?",
+            sanitized_text="Can I overwatch?",
+            timestamp=datetime.now(timezone.utc),
+            conversation_context_id="channel123:user456",
+            pii_redacted=False,
+        )
+        # Should not raise
+        query.validate()
+
+    def test_is_expired_not_expired(self):
+        """Test query is not expired within retention period."""
+        query = UserQuery(
+            query_id=UUID("12345678-1234-5678-1234-567812345678"),
+            user_id="hashed_user_id",
+            channel_id="channel123",
+            message_text="Can I overwatch?",
+            sanitized_text="Can I overwatch?",
+            timestamp=datetime.now(timezone.utc),
+            conversation_context_id="channel123:user456",
+        )
+
+        assert query.is_expired() is False
+
+    def test_is_expired_expired(self):
+        """Test query is expired after 7 days."""
+        old_timestamp = datetime.now(timezone.utc) - timedelta(days=8)
+
+        query = UserQuery(
+            query_id=UUID("12345678-1234-5678-1234-567812345678"),
+            user_id="hashed_user_id",
+            channel_id="channel123",
+            message_text="Can I overwatch?",
+            sanitized_text="Can I overwatch?",
+            timestamp=old_timestamp,
+            conversation_context_id="channel123:user456",
+        )
+
+        assert query.is_expired() is True
+
+    def test_is_expired_exactly_7_days(self):
+        """Test query exactly at 7 day boundary."""
+        exactly_7_days = datetime.now(timezone.utc) - timedelta(days=7, seconds=1)
+
+        query = UserQuery(
+            query_id=UUID("12345678-1234-5678-1234-567812345678"),
+            user_id="hashed_user_id",
+            channel_id="channel123",
+            message_text="Can I overwatch?",
+            sanitized_text="Can I overwatch?",
+            timestamp=exactly_7_days,
+            conversation_context_id="channel123:user456",
+        )
+
+        assert query.is_expired() is True
+
+    def test_from_discord_message(self):
+        """Test creating UserQuery from Discord message."""
+        discord_user_id = "123456789"
+        channel_id = "channel123"
+        message = "Can I use overwatch during a charge?"
+        sanitized = "Can I use overwatch during a charge?"
+
+        query = UserQuery.from_discord_message(
+            discord_user_id=discord_user_id,
+            channel_id=channel_id,
+            message_text=message,
+            sanitized_text=sanitized,
+            pii_redacted=False,
+        )
+
+        assert isinstance(query.query_id, UUID)
+        assert query.user_id == UserQuery.hash_user_id(discord_user_id)
+        assert query.channel_id == channel_id
+        assert query.message_text == message
+        assert query.sanitized_text == sanitized
+        assert query.pii_redacted is False
+        assert isinstance(query.timestamp, datetime)
+        assert query.conversation_context_id == f"{channel_id}:{query.user_id}"
+
+    def test_from_discord_message_with_pii_redaction(self):
+        """Test creating UserQuery with PII redacted."""
+        query = UserQuery.from_discord_message(
+            discord_user_id="123456789",
+            channel_id="channel123",
+            message_text="Original message",
+            sanitized_text="Redacted message",
+            pii_redacted=True,
+        )
+
+        assert query.pii_redacted is True
+
+    def test_from_discord_message_hashes_user_id(self):
+        """Test that from_discord_message properly hashes the user ID."""
+        raw_user_id = "987654321"
+
+        query = UserQuery.from_discord_message(
+            discord_user_id=raw_user_id,
+            channel_id="channel123",
+            message_text="Test",
+            sanitized_text="Test",
+        )
+
+        # User ID should be hashed, not raw
+        assert query.user_id != raw_user_id
+        assert query.user_id == UserQuery.hash_user_id(raw_user_id)
+
+    def test_from_discord_message_creates_context_id(self):
+        """Test that from_discord_message creates proper context ID."""
+        discord_user_id = "123456789"
+        channel_id = "channel456"
+
+        query = UserQuery.from_discord_message(
+            discord_user_id=discord_user_id,
+            channel_id=channel_id,
+            message_text="Test",
+            sanitized_text="Test",
+        )
+
+        hashed_user = UserQuery.hash_user_id(discord_user_id)
+        expected_context_id = f"{channel_id}:{hashed_user}"
+
+        assert query.conversation_context_id == expected_context_id
+
+    def test_message_text_and_sanitized_text_different(self):
+        """Test handling when message and sanitized text differ."""
+        query = UserQuery.from_discord_message(
+            discord_user_id="123456789",
+            channel_id="channel123",
+            message_text="My email is test@example.com",
+            sanitized_text="My email is [REDACTED]",
+            pii_redacted=True,
+        )
+
+        assert query.message_text == "My email is test@example.com"
+        assert query.sanitized_text == "My email is [REDACTED]"
+        assert query.pii_redacted is True


### PR DESCRIPTION
Add unit tests for all model classes in src/models/ to achieve >80% code coverage:
- test_pdf_update.py: Tests for PDFUpdate model including hash computation, validation, version checking, and factory methods
- test_conversation_context.py: Tests for ConversationContext and Message including message management, expiration, and context creation
- test_bot_response.py: Tests for BotResponse and Citation including validation, Discord message splitting, and response creation
- test_ingestion_job.py: Tests for IngestionJob including job lifecycle, metrics tracking, and error handling
- test_user_query.py: Tests for UserQuery including GDPR-compliant user ID hashing and query expiration
- test_rule_document.py: Tests for RuleDocument including content hashing, validation, and markdown file parsing
- test_structured_response.py: Tests for StructuredLLMResponse including JSON parsing and markdown conversion
- test_rag_context.py: Tests for RAGContext and DocumentChunk including relevance scoring and retrieval

All tests are meaningful and cover the main functionality of each model without focusing on error cases as requested.